### PR TITLE
Fix empty release changelogs; ship multi-arch + upgrade Go 1.26.4 and CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Keep host-built artifacts out of the Docker build context. Otherwise `COPY . .`
+# would carry a single-architecture runner/otelcol-contrib into every platform of
+# the multi-arch build, and docker/Dockerfile skips `make getotelcol` when that
+# file already exists — causing e.g. the linux/amd64 image to embed an arm64
+# collector. Excluding it forces each platform build to fetch its own arch.
+build/
+runner/otelcol-contrib

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -1,0 +1,42 @@
+name: "Docker build and push"
+description: "Build and push the opentelemetry-infinity image to Docker Hub (multi-arch)."
+inputs:
+  tags:
+    description: "Newline-separated list of image tags."
+    required: true
+  platforms:
+    description: "Target platforms."
+    required: false
+    default: "linux/amd64,linux/arm64"
+  push:
+    description: "Whether to push the image."
+    required: false
+    default: "true"
+  dockerhub-username:
+    description: "Docker Hub username."
+    required: true
+  dockerhub-token:
+    description: "Docker Hub token."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+    - name: Login to Docker Hub
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}
+    - name: Build image and push
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      with:
+        context: .
+        file: docker/Dockerfile
+        platforms: ${{ inputs.platforms }}
+        push: ${{ inputs.push }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        tags: ${{ inputs.tags }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,26 +96,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 #v3.8.0
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+      - name: Build and push image
+        uses: ./.github/actions/docker-build-push
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build image and push
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 #v6.10.0
-        with:
-          context: .
-          file: docker/Dockerfile
-          platforms: linux/amd64, linux/arm64
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           tags: netboxlabs/opentelemetry-infinity:develop
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,28 +21,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.x'
           check-latest: true
       - name: get otelcol-contrib
         run: make getotelcol
       - name: Lint
-        uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 #v9.1.0
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.4.0
+          version: v2.12.2
           working-directory: .
           args: --config .github/golangci.yaml
+      - name: Shellcheck
+        run: shellcheck scripts/*.sh
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.x'
 
@@ -70,7 +72,7 @@ jobs:
 
       - name: Find comment
         if: ${{ github.event_name == 'pull_request' }}
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e #v3.1.0
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: existing-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -79,7 +81,7 @@ jobs:
 
       - name: Post comment
         if: ${{ github.event_name == 'pull_request' }}
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.existing-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -94,7 +96,7 @@ jobs:
     needs: [ test ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build and push image
         uses: ./.github/actions/docker-build-push

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           check-latest: true
       - name: get otelcol-contrib
         run: make getotelcol
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
 
       - name: get otelcol-contrib
         run: make getotelcol

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -8,6 +8,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "docker/**"
+      - ".dockerignore"
       - "Makefile"
       - ".github/workflows/container-scan.yaml"
 

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build image
-        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: docker/Dockerfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,30 +114,12 @@ jobs:
             otelcol-contrib-arm64.zip
             checksums.txt
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 #v3.8.0
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+      - name: Build and push image
+        uses: ./.github/actions/docker-build-push
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build image and push
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 #v6.10.0
-        env:
-          TAG: ${{needs.check.outputs.release}}
-        with:
-          context: .
-          file: docker/Dockerfile
-          platforms: linux/amd64, linux/arm64
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           tags: |
             netboxlabs/opentelemetry-infinity:develop
             netboxlabs/opentelemetry-infinity:latest
-            netboxlabs/opentelemetry-infinity:${{ env.TAG }}
+            netboxlabs/opentelemetry-infinity:${{ needs.check.outputs.release }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
   check:
     outputs:
       release: ${{ steps.early.outputs.release }}
+      previous: ${{ steps.early.outputs.previous }}
     runs-on: ubuntu-latest
     steps:
       - id: early
@@ -27,17 +28,19 @@ jobs:
             release=$OTEL_LATEST_VERSION
           fi
           echo "release=$release" >> $GITHUB_OUTPUT
+          echo "previous=$INF_LATEST_VERSION" >> $GITHUB_OUTPUT
   release:
     runs-on: ubuntu-latest
     needs: check
     if: needs.check.outputs.release != ''
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Download Version
         env:
           RELEASE: ${{needs.check.outputs.release}}
         run: |
-          echo "LAST_TAG=`git tag --sort=committerdate | tail -1`" >> $GITHUB_ENV
           ARTIFACT_VERSION=${RELEASE:1}
           echo "ARTIFACT_VERSION=$ARTIFACT_VERSION" >> $GITHUB_ENV
 
@@ -82,11 +85,10 @@ jobs:
 
       - name: Generate release changelog
         env:
-          LAST_TAG: ${{ env.LAST_TAG }}
-        run: |
-          echo "# What's new" > changelog.md
-          git log ${{ env.LAST_TAG }}..HEAD --pretty=format:"$ad- %s [%an]" >> changelog.md
-          sed -i -e "s/- /• /g" changelog.md
+          GH_TOKEN: ${{ github.token }}
+          PREV: ${{ needs.check.outputs.previous }}
+          NEW: ${{ needs.check.outputs.release }}
+        run: bash ./scripts/release-notes.sh "$PREV" "$NEW" > changelog.md
 
       - name: Release
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 #v2.3.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     needs: check
     if: needs.check.outputs.release != ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Download Version
@@ -54,7 +54,7 @@ jobs:
           rm -rf .temp/
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.x'
 
@@ -101,7 +101,7 @@ jobs:
         run: sha256sum otlpinf-amd64.zip otlpinf-arm64.zip otelcol-contrib-amd64.zip otelcol-contrib-arm64.zip > checksums.txt
 
       - name: Release
-        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 #v2.3.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         env:
           TAG: ${{needs.check.outputs.release}}
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
 
       - name: Build Binary
         run: make build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,7 +69,7 @@ jobs:
           zip -j otlpinf-amd64.zip build/otlpinf
           zip -j otelcol-contrib-amd64.zip runner/otelcol-contrib
 
-      - name: Download and zip arm64
+      - name: Download arm64 collector and build arm64 binaries
         env:
           RELEASE: ${{needs.check.outputs.release}}
           ARTIFACT_VERSION: ${{ env.ARTIFACT_VERSION }}
@@ -78,9 +78,16 @@ jobs:
           ARTIFACT_URL="https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/$RELEASE/$ARTIFACT"
           mkdir .temp/
           wget -O .temp/otelcol-contrib.tar.gz $ARTIFACT_URL
-
           tar -xvzf .temp/otelcol-contrib.tar.gz -C .temp/
+
+          # arm64 otelcol-contrib artifact
           zip -j otelcol-contrib-arm64.zip .temp/otelcol-contrib
+
+          # Embed the arm64 collector and cross-build the arm64 otlpinf.
+          mv .temp/otelcol-contrib runner/otelcol-contrib
+          make build GOARCH=arm64
+          zip -j otlpinf-arm64.zip build/otlpinf
+
           rm -rf .temp/
 
       - name: Generate release changelog
@@ -89,6 +96,9 @@ jobs:
           PREV: ${{ needs.check.outputs.previous }}
           NEW: ${{ needs.check.outputs.release }}
         run: bash ./scripts/release-notes.sh "$PREV" "$NEW" > changelog.md
+
+      - name: Generate checksums
+        run: sha256sum otlpinf-amd64.zip otlpinf-arm64.zip otelcol-contrib-amd64.zip otelcol-contrib-arm64.zip > checksums.txt
 
       - name: Release
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 #v2.3.2
@@ -99,8 +109,10 @@ jobs:
           body_path: ./changelog.md
           files: |
             otlpinf-amd64.zip
+            otlpinf-arm64.zip
             otelcol-contrib-amd64.zip
             otelcol-contrib-arm64.zip
+            checksums.txt
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.25.4
+golang 1.26.4

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG GOARCH
 ARG GOARM
 
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /go/src/github.com/netboxlabs/opentelemetry-infinity
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/opentelemetry-infinity
 
-go 1.25.4
+go 1.26.4
 
 require (
 	github.com/amenzhinsky/go-memexec v0.7.1

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -63,10 +63,12 @@ else
   # Drop upstream's leading "Check the ... changelog" line (we built our own),
   # strip from "## Changelog" to EOF (raw commit-hash list = noise),
   # drop the redundant "## <version>" heading, then trim leading blank lines.
+  # Escape regex metacharacters (dots) in the version before using it in a sed pattern.
+  new_re=${NEW//./\\.}
   upstream_curated="$(printf '%s\n' "$upstream_raw" \
     | sed '/^Check the .*for changelogs on specific components\.$/d' \
     | awk 'BEGIN{keep=1} /^## Changelog[[:space:]]*$/{keep=0} keep' \
-    | sed "/^## ${NEW}[[:space:]]*\$/d" \
+    | sed "/^## ${new_re}[[:space:]]*\$/d" \
     | awk 'NF{f=1} f')"
   if [[ -n "${upstream_curated//[[:space:]]/}" ]]; then
     printf '%s\n' "$upstream_curated"

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Assemble the GitHub Release body for an opentelemetry-infinity release.
+#
+# Usage:
+#   scripts/release-notes.sh <prev_version> <new_version>
+#   e.g. scripts/release-notes.sh v0.153.0 v0.154.0
+#
+# Output: assembled Markdown on stdout.
+#
+# Env:
+#   GH_TOKEN            token used by `gh api` to fetch the upstream release notes.
+#   UPSTREAM_BODY_FILE  (test only) read the upstream collector-releases body from this
+#                       file instead of calling the GitHub API.
+#
+set -euo pipefail
+
+PREV="${1:-}"
+NEW="${2:-}"
+
+if [[ -z "$PREV" || -z "$NEW" ]]; then
+  echo "usage: $0 <prev_version> <new_version>" >&2
+  exit 2
+fi
+
+CONTRIB_URL="https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/${NEW}"
+CORE_URL="https://github.com/open-telemetry/opentelemetry-collector/releases/tag/${NEW}"
+
+# 1. Header line (constructed by us; robust to upstream format drift).
+printf 'Check the [%s contrib changelog](%s) and the [%s core changelog](%s) for changelogs on specific components.\n' \
+  "$NEW" "$CONTRIB_URL" "$NEW" "$CORE_URL"
+
+# 2. opentelemetry-infinity changes (git log since the previous release).
+printf '\n## opentelemetry-infinity changes\n'
+otlpinf_changes="$(git log "${PREV}..HEAD" --pretty=format:'• %s [%an]' 2>/dev/null || true)"
+if [[ -n "$otlpinf_changes" ]]; then
+  printf '%s\n' "$otlpinf_changes"
+else
+  printf '_Embedded otelcol-contrib upgraded %s → %s; no otlpinf code changes._\n' "$PREV" "$NEW"
+fi
+
+# 3. Embedded otelcol-contrib upstream notes.
+fetch_upstream() {
+  if [[ -n "${UPSTREAM_BODY_FILE:-}" ]]; then
+    [[ -f "$UPSTREAM_BODY_FILE" ]] || return 1
+    cat "$UPSTREAM_BODY_FILE"
+    return
+  fi
+  # `// ""` => a null/absent body becomes an empty string, not the literal "null".
+  gh api "repos/open-telemetry/opentelemetry-collector-releases/releases/tags/${NEW}" --jq '.body // ""'
+}
+
+# tr -d '\r' normalizes CRLF so the `$`-anchored seds below match regardless of
+# upstream line endings. pipefail makes a failed fetch propagate to the `if`.
+if ! upstream_raw="$(fetch_upstream 2>/dev/null | tr -d '\r')"; then
+  upstream_raw=""
+fi
+
+printf '\n## Embedded otelcol-contrib %s\n' "$NEW"
+if [[ -z "$upstream_raw" ]]; then
+  printf '_Upstream release notes for %s could not be fetched. See the changelog links above._\n' "$NEW"
+else
+  # Drop upstream's leading "Check the ... changelog" line (we built our own),
+  # strip from "## Changelog" to EOF (raw commit-hash list = noise),
+  # drop the redundant "## <version>" heading, then trim leading blank lines.
+  upstream_curated="$(printf '%s\n' "$upstream_raw" \
+    | sed '/^Check the .*for changelogs on specific components\.$/d' \
+    | awk 'BEGIN{keep=1} /^## Changelog[[:space:]]*$/{keep=0} keep' \
+    | sed "/^## ${NEW}[[:space:]]*\$/d" \
+    | awk 'NF{f=1} f')"
+  if [[ -n "${upstream_curated//[[:space:]]/}" ]]; then
+    printf '%s\n' "$upstream_curated"
+  else
+    printf '_No curated upstream notes for this version. See the changelog links above._\n'
+  fi
+fi

--- a/scripts/release-notes_test.sh
+++ b/scripts/release-notes_test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Tests for release-notes.sh. Injects the upstream body from a fixture (offline).
+set -uo pipefail
+# shellcheck disable=SC2164 # repo-root cd: relative script paths below fail loudly if this cd fails
+cd "$(dirname "$0")/.."
+
+FIXTURE="scripts/testdata/collector-releases-v0.154.0.txt"
+fail=0
+
+# Case A: no otlpinf commits (prev == HEAD -> empty git range -> fallback line)
+out="$(UPSTREAM_BODY_FILE="$FIXTURE" scripts/release-notes.sh HEAD v0.154.0)"
+
+assert_contains() {
+  if printf '%s' "$out" | grep -qF -- "$1"; then echo "ok: contains '$1'";
+  else echo "FAIL: missing '$1'"; fail=1; fi
+}
+assert_absent() {
+  if printf '%s' "$out" | grep -qF -- "$1"; then echo "FAIL: should not contain '$1'"; fail=1;
+  else echo "ok: absent '$1'"; fi
+}
+
+assert_contains "Check the [v0.154.0 contrib changelog]"
+assert_contains "[v0.154.0 core changelog]"
+assert_contains "## opentelemetry-infinity changes"
+assert_contains "no otlpinf code changes"
+assert_contains "## Embedded otelcol-contrib v0.154.0"
+assert_contains "Remove deprecated JMX receiver"
+assert_absent  "4ae7f285f3df635cb3c456f8dfba045973bb4d91"
+assert_absent  "## Changelog"
+
+# Case B: otlpinf has commits (HEAD~1..HEAD -> at least one bullet)
+out2="$(UPSTREAM_BODY_FILE="$FIXTURE" scripts/release-notes.sh HEAD~1 v0.154.0)"
+if printf '%s' "$out2" | grep -q '^• '; then echo "ok: otlpinf commits listed";
+else echo "FAIL: expected '• ' commit bullets"; fail=1; fi
+
+# Case C: upstream fetch unavailable (missing fixture -> soft fallback, exit 0)
+out3="$(UPSTREAM_BODY_FILE="/nonexistent/file" scripts/release-notes.sh HEAD v0.154.0)"
+if printf '%s' "$out3" | grep -qF "could not be fetched"; then echo "ok: soft-fail fallback";
+else echo "FAIL: expected soft-fail fallback"; fail=1; fi
+
+if [[ $fail -ne 0 ]]; then echo "TESTS FAILED"; exit 1; fi
+echo "ALL TESTS PASSED"

--- a/scripts/release-notes_test.sh
+++ b/scripts/release-notes_test.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # Tests for release-notes.sh. Injects the upstream body from a fixture (offline).
+# NOTE: `set -e` is intentionally omitted so every assertion runs and accumulates
+# into `fail` rather than aborting on the first failure.
 set -uo pipefail
 # shellcheck disable=SC2164 # repo-root cd: relative script paths below fail loudly if this cd fails
 cd "$(dirname "$0")/.."
 
 FIXTURE="scripts/testdata/collector-releases-v0.154.0.txt"
+SCRIPT="$(pwd)/scripts/release-notes.sh"
+ABS_FIXTURE="$(pwd)/$FIXTURE"
 fail=0
 
 # Case A: no otlpinf commits (prev == HEAD -> empty git range -> fallback line)
@@ -28,15 +32,41 @@ assert_contains "Remove deprecated JMX receiver"
 assert_absent  "4ae7f285f3df635cb3c456f8dfba045973bb4d91"
 assert_absent  "## Changelog"
 
-# Case B: otlpinf has commits (HEAD~1..HEAD -> at least one bullet)
-out2="$(UPSTREAM_BODY_FILE="$FIXTURE" scripts/release-notes.sh HEAD~1 v0.154.0)"
-if printf '%s' "$out2" | grep -q '^• '; then echo "ok: otlpinf commits listed";
-else echo "FAIL: expected '• ' commit bullets"; fail=1; fi
+# Case B: otlpinf has commits -> bullet list. Uses a throwaway repo so the test does
+# NOT depend on the ambient checkout depth (HEAD~1 may not exist in a shallow clone).
+tmp_repo="$(mktemp -d)"
+(
+  cd "$tmp_repo" || exit 1
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  git commit -q --allow-empty -m "base"
+  git commit -q --allow-empty -m "feat: add a thing"
+)
+out2="$(cd "$tmp_repo" && UPSTREAM_BODY_FILE="$ABS_FIXTURE" "$SCRIPT" HEAD~1 v0.154.0)"
+rm -rf "$tmp_repo"
+if printf '%s' "$out2" | grep -q '^• feat: add a thing '; then echo "ok: otlpinf commits listed";
+else echo "FAIL: expected '• feat: add a thing' bullet"; fail=1; fi
 
 # Case C: upstream fetch unavailable (missing fixture -> soft fallback, exit 0)
 out3="$(UPSTREAM_BODY_FILE="/nonexistent/file" scripts/release-notes.sh HEAD v0.154.0)"
 if printf '%s' "$out3" | grep -qF "could not be fetched"; then echo "ok: soft-fail fallback";
 else echo "FAIL: expected soft-fail fallback"; fail=1; fi
+
+# Case D: CRLF upstream body still curates correctly (regression guard for `tr -d '\r'`).
+# Build a CRLF copy portably (awk ORS works on both GNU and BSD awk; `sed 's/$/\r/'` does not).
+crlf_fixture="$(mktemp)"
+awk 'BEGIN{ORS="\r\n"}1' "$FIXTURE" > "$crlf_fixture"
+out4="$(UPSTREAM_BODY_FILE="$crlf_fixture" scripts/release-notes.sh HEAD v0.154.0)"
+rm -f "$crlf_fixture"
+header_count="$(printf '%s\n' "$out4" | grep -c 'for changelogs on specific components')"
+if printf '%s' "$out4" | grep -qF "Remove deprecated JMX receiver" \
+   && ! printf '%s' "$out4" | grep -qF "## Changelog" \
+   && [ "$header_count" -eq 1 ]; then
+  echo "ok: CRLF body curated (single header, deprecation kept, changelog stripped)";
+else
+  echo "FAIL: CRLF handling regression (header_count=$header_count)"; fail=1;
+fi
 
 if [[ $fail -ne 0 ]]; then echo "TESTS FAILED"; exit 1; fi
 echo "ALL TESTS PASSED"

--- a/scripts/testdata/collector-releases-v0.154.0.txt
+++ b/scripts/testdata/collector-releases-v0.154.0.txt
@@ -1,0 +1,14 @@
+Check the [v0.154.0 contrib changelog](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.154.0) and the [v0.154.0 core changelog](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.154.0) for changelogs on specific components.
+
+## v0.154.0
+
+### 🚩 Deprecations 🚩
+
+- `jmxreceiver`: Remove deprecated JMX receiver from contrib distribution (#1519)
+
+## Changelog
+* 4ae7f285f3df635cb3c456f8dfba045973bb4d91 Update version to 0.154.0 (#1525)
+* a25341e2c9ee249513d647e5d83e314e4fee3fac chore(deps): update opentelemetry collector components (#1523)
+* 6359fa04052f0e31e987dda2cdeefb3879cc02cf chore(deps): update dockerfile deps (#1520)
+* b17d62576dcb1d86e94a7f394eefe50528e6037d chore(deps): update github-actions deps to v4.36.2 (#1521)
+* 2b67e1f3523334aee7f2fe5ed167805ef70943b3 chore(deps): update module go.opentelemetry.io/ebpf-profiler to v0.0.202623 (#1522)


### PR DESCRIPTION
## Summary

Overhauls the release pipeline so each release is actually informative, and modernizes the toolchain/CI.

- **Non-empty changelogs** — new `scripts/release-notes.sh` assembles each release body from: a header line linking the version's contrib & core changelogs, opentelemetry-infinity's own changes (`git log <prev>..HEAD`), and the upstream `opentelemetry-collector-releases` curated notes (raw `## Changelog` commit list and redundant `## <version>` heading stripped). Modeled on what upstream publishes.
- **Fixes the broken generation** — the old step produced empty bodies because the release job checked out shallow (no tags) and used a bogus `git tag` for the previous version. Now: `fetch-depth: 0` + a precise `previous` output from the `check` job.
- **Multi-arch `otlpinf`** — also cross-builds and ships `otlpinf-arm64.zip` (previously only amd64 of `otlpinf` shipped, despite the image being multi-arch), plus a `checksums.txt` (sha256) over all four artifacts.
- **Go 1.25.4 → 1.26.4** across `.tool-versions`, `go.mod`, `docker/Dockerfile`, and both workflows.
- **CI hardening** — all actions in `build.yaml`/`release.yaml` bumped to latest and SHA-pinned; the duplicated docker build/push block extracted into a composite action (`.github/actions/docker-build-push`); `shellcheck` added to the lint job; scan-workflow shared pins aligned for repo-wide consistency.

## Test Plan

- [x] `scripts/release-notes_test.sh` passes (11 assertions incl. hermetic git-log case, CRLF normalization, soft-fail fallback)
- [x] `shellcheck scripts/*.sh` clean
- [x] `make build` succeeds on Go 1.26.4; arm64 cross-compile verified (`make build GOARCH=arm64` → aarch64 ELF)
- [x] `make lint` (golangci-lint v2.12.2) → 0 issues
- [ ] `make test` on CI `ubuntu-latest` (the embedded collector is a Linux ELF, so the exec-based tests only run on Linux, not local macOS)
- [ ] Verify a real release: confirm the generated body has all three sections and the release attaches 4 zips + `checksums.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)