### PR TITLE
test: raise otlpinf and runner coverage with exec-free unit tests

### DIFF
--- a/otlpinf/handlers_test.go
+++ b/otlpinf/handlers_test.go
@@ -1,0 +1,120 @@
+package otlpinf
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/netboxlabs/opentelemetry-infinity/config"
+)
+
+func newTestOtlp() *OltpInf {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	o := NewOtlp(logger, &config.Config{ServerHost: TestHost})
+	o.setupRouter()
+	return o
+}
+
+// getCapabilities returns 400 when the stored capabilities are not valid YAML.
+func TestGetCapabilitiesError(t *testing.T) {
+	o := newTestOtlp()
+	o.capabilities = []byte("{") // invalid YAML -> yson.YAMLToJSON fails
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/capabilities", nil)
+	o.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// createPolicy returns 409 when the policy already exists (no collector started).
+func TestCreatePolicyConflict(t *testing.T) {
+	o := newTestOtlp()
+	o.policies["existing"] = RunnerInfo{}
+
+	body := "existing:\n  receivers:\n    otlp:\n  exporters:\n    debug:\n  service: {}\n"
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", PoliciesAPI, strings.NewReader(body))
+	req.Header.Set("Content-Type", HTTPYamlContent)
+	o.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+}
+
+// createPolicy returns 400 when Configure fails (invalid policies dir), before any exec.
+func TestCreatePolicyConfigureError(t *testing.T) {
+	o := newTestOtlp()
+	o.policiesDir = "/nonexistent/policies/dir"
+
+	body := "p1:\n  receivers:\n    otlp:\n  exporters:\n    debug:\n  service: {}\n"
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", PoliciesAPI, strings.NewReader(body))
+	req.Header.Set("Content-Type", HTTPYamlContent)
+	o.router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// Stop with no http server removes the policies dir and clears state.
+func TestStopRemovesPoliciesDir(t *testing.T) {
+	o := newTestOtlp()
+	dir := t.TempDir()
+	o.policiesDir = dir
+	o.cancelFunction = func() {}
+
+	o.Stop(context.Background())
+
+	if o.policiesDir != "" {
+		t.Errorf("expected policiesDir cleared, got %q", o.policiesDir)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("expected dir %q removed, stat err = %v", dir, err)
+	}
+}
+
+// Stop shuts down and clears a non-nil http server.
+func TestStopShutsDownServer(t *testing.T) {
+	o := newTestOtlp()
+	o.httpServer = &http.Server{Addr: "127.0.0.1:0"}
+	o.cancelFunction = func() {}
+
+	o.Stop(context.Background())
+
+	if o.httpServer != nil {
+		t.Errorf("expected httpServer cleared")
+	}
+}
+
+// startFailure delivers the error and cleans up an existing policies dir.
+func TestStartFailureCleansPoliciesDir(t *testing.T) {
+	o := newTestOtlp()
+	dir := t.TempDir()
+	o.policiesDir = dir
+
+	ch := o.startFailure(errors.New("boom"))
+	err, ok := <-ch
+	if !ok || err == nil {
+		t.Fatalf("expected an error on the channel, ok=%v err=%v", ok, err)
+	}
+	if _, more := <-ch; more {
+		t.Errorf("expected channel closed after one error")
+	}
+	if o.policiesDir != "" {
+		t.Errorf("expected policiesDir cleared, got %q", o.policiesDir)
+	}
+	if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+		t.Errorf("expected dir %q removed", dir)
+	}
+}

--- a/runner/runner_logs_test.go
+++ b/runner/runner_logs_test.go
@@ -1,0 +1,116 @@
+package runner
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func hasAttr(attrs []slog.Attr, key string) bool {
+	for _, a := range attrs {
+		if a.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func TestMapCollectorLevel(t *testing.T) {
+	cases := map[string]slog.Level{
+		"debug":   slog.LevelDebug,
+		"DEBUG":   slog.LevelDebug,
+		"warn":    slog.LevelWarn,
+		"warning": slog.LevelWarn,
+		"WARN":    slog.LevelWarn,
+		"error":   slog.LevelError,
+		"err":     slog.LevelError,
+		"fatal":   slog.LevelError,
+		"info":    slog.LevelInfo,
+		"unknown": slog.LevelInfo,
+		"":        slog.LevelInfo,
+	}
+	for in, want := range cases {
+		if got := mapCollectorLevel(in); got != want {
+			t.Errorf("mapCollectorLevel(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestShouldSuppressCollectorLog(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"empty", "", false},
+		{"whitespace", "   ", false},
+		{"memfd warning", "2024-01-01\twarn\tinternal\tFailed to get executable path: lstat /memfd:foo", true},
+		{"ordinary line", "2024-01-01\tinfo\tservice\tEverything is fine", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldSuppressCollectorLog(tc.line); got != tc.want {
+				t.Errorf("shouldSuppressCollectorLog(%q) = %v, want %v", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseCollectorLog(t *testing.T) {
+	t.Run("empty line", func(t *testing.T) {
+		msg, level, attrs := parseCollectorLog("")
+		if msg != "" || level != slog.LevelInfo || attrs != nil {
+			t.Errorf("got (%q, %v, %v)", msg, level, attrs)
+		}
+	})
+
+	t.Run("single field no tabs is trimmed", func(t *testing.T) {
+		msg, level, attrs := parseCollectorLog("  just a message  ")
+		if msg != "just a message" || level != slog.LevelInfo || attrs != nil {
+			t.Errorf("got (%q, %v, %v)", msg, level, attrs)
+		}
+	})
+
+	t.Run("level source and plain message", func(t *testing.T) {
+		line := "2024-01-01T00:00:00Z\twarn\totelcol.receiver\tsomething happened"
+		msg, level, attrs := parseCollectorLog(line)
+		if msg != "something happened" {
+			t.Errorf("msg = %q", msg)
+		}
+		if level != slog.LevelWarn {
+			t.Errorf("level = %v", level)
+		}
+		if !hasAttr(attrs, "collector_source") {
+			t.Errorf("expected collector_source attr, got %v", attrs)
+		}
+		if hasAttr(attrs, "collector_message") {
+			t.Errorf("did not expect collector_message attr for plain text")
+		}
+	})
+
+	t.Run("json message adds structured attr", func(t *testing.T) {
+		line := "2024-01-01T00:00:00Z\tinfo\tsrc\t{\"k\":\"v\"}"
+		msg, _, attrs := parseCollectorLog(line)
+		if msg != `{"k":"v"}` {
+			t.Errorf("msg = %q", msg)
+		}
+		if !hasAttr(attrs, "collector_message") {
+			t.Errorf("expected collector_message attr, got %v", attrs)
+		}
+	})
+
+	t.Run("json payload adds structured payload", func(t *testing.T) {
+		line := "ts\tinfo\tsrc\tmessage\t{\"count\":3}"
+		_, _, attrs := parseCollectorLog(line)
+		if !hasAttr(attrs, "collector_payload") {
+			t.Errorf("expected collector_payload attr, got %v", attrs)
+		}
+	})
+
+	t.Run("non-json payload kept as string", func(t *testing.T) {
+		line := "ts\tinfo\tsrc\tmessage\tplain payload text"
+		_, _, attrs := parseCollectorLog(line)
+		if !hasAttr(attrs, "collector_payload") {
+			t.Errorf("expected collector_payload attr, got %v", attrs)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds deterministic, **exec-free** unit tests that raise package coverage without touching production code:

- `runner` **66.4% → 88.3%** — table-driven tests for the collector-log helpers (`parseCollectorLog`, `shouldSuppressCollectorLog`, `mapCollectorLevel`), which were ~0% because they only run inside the `Start` stderr goroutine.
- `otlpinf` **79.5% → 85.0%** — `httptest`-based tests for error/lifecycle branches the existing integration tests don't hit: `getCapabilities` error, `createPolicy` conflict (409) and Configure-failure (400), `Stop` (with and without an http server), and `startFailure` cleanup.

New tests never exec the embedded `otelcol-contrib`, so they pass on macOS and Linux (the pre-existing exec integration tests still cover `Start`/`GetCapabilities` on CI's Linux runner).

**Why not 90%?** The remaining uncovered lines are error branches reachable only via dependency-injection refactoring (faking `memexec`/`exec.Cmd`/file-I/O failures). That was deliberately scoped out to keep this change test-only; 85%/88% is the exec-free ceiling.

## Test Plan

- [x] New tests pass on macOS: `go test ./runner/ ./otlpinf/ -run '<new tests>'`
- [x] Full suite green on Linux (Docker `golang:1.26-alpine`); coverage `otlpinf` 85.0%, `runner` 88.3%
- [x] `make lint` → 0 issues; `go vet ./...` clean
- [x] No production code changed

## Notes (pre-existing, out of scope — flagging for follow-up)

- `go test -race` (used by CI's `make test-coverage`) can intermittently trip a **data race** in `runner.go`'s `Start` goroutines (concurrent access to `r.state`/`r.cmd`). Present on `main` today; may make the CI test job flaky. Worth a dedicated fix.
- `createPolicy`'s rollback loops (`server.go`) call `delete(o.policies, policy)` using the outer loop variable instead of `p`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)